### PR TITLE
update test

### DIFF
--- a/Datez/Datez.xcodeproj/project.pbxproj
+++ b/Datez/Datez.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = kitz;
 				TargetAttributes = {
 					823F18631BF43A9D008DF5F8 = {
@@ -543,11 +543,11 @@
 					};
 					82D57CE11BEE740B0071C345 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					82D57CEB1BEE740B0071C345 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					82D57D691BEF04250071C345 = {
 						LastSwiftMigration = 0800;
@@ -849,14 +849,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -904,14 +910,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -959,6 +971,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kitz.Datez;
 				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -976,6 +990,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kitz.Datez;
 				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -986,6 +1002,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kitz.DatezTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -996,6 +1014,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kitz.DatezTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Datez/DatezTests/ExtensionTests/CountingTests.swift
+++ b/Datez/DatezTests/ExtensionTests/CountingTests.swift
@@ -60,7 +60,7 @@ class CountingTests: XCTestCase {
     func testMonthsCounting() {
         // it is not predictable whether a month is 28, 29, 30, or 31 days
         // as stated in the readme, this should be used for ballpark numbers
-        XCTAssertEqualWithAccuracy(Double(2920.days.timeInterval.totalMonths), 95, accuracy: 1.0)
+        XCTAssertEqual(Double(2920.days.timeInterval.totalMonths), 95, accuracy: 1.0)
 
         XCTAssertEqual(32.days.timeInterval.totalMonths, 1)
         XCTAssertEqual(27.days.timeInterval.totalMonths, 0)

--- a/Datez/DatezTests/ExtensionTests/FoundationConversionTests/NSTimeIntervalConversionTests.swift
+++ b/Datez/DatezTests/ExtensionTests/FoundationConversionTests/NSTimeIntervalConversionTests.swift
@@ -24,10 +24,10 @@ class NSTimeIntervalConversionTests: XCTestCase {
     
     func testTimeIntervalFromCalendarComponents() {
         
-        XCTAssertEqualWithAccuracy(11.minute.timeInterval, 11 * 60.seconds.timeInterval, accuracy: highAccuracy)
-        XCTAssertEqualWithAccuracy(20.hours.timeInterval, 20 * 60.minutes.timeInterval, accuracy: highAccuracy)
-        XCTAssertEqualWithAccuracy(12.days.timeInterval, 12 * 24.hours.timeInterval, accuracy: lowAccuracy)
-        XCTAssertEqualWithAccuracy(3.months.timeInterval, 3 * 31.days.timeInterval, accuracy: ballparkAccuracy)
+        XCTAssertEqual(11.minute.timeInterval, 11 * 60.seconds.timeInterval, accuracy: highAccuracy)
+        XCTAssertEqual(20.hours.timeInterval, 20 * 60.minutes.timeInterval, accuracy: highAccuracy)
+        XCTAssertEqual(12.days.timeInterval, 12 * 24.hours.timeInterval, accuracy: lowAccuracy)
+        XCTAssertEqual(3.months.timeInterval, 3 * 31.days.timeInterval, accuracy: ballparkAccuracy)
     }
     
     func testCalendarComponentsFromTimeInterval() {


### PR DESCRIPTION
Salam,

I can't record the Gif because I can't run playground, because some files need to be updated. So I updated them in this PR. Also, I got two warnings:

> The use of Swift 3 @objc inference in Swift 4 mode is deprecated. Please address deprecated @objc inference warnings, test your code with “Use of deprecated Swift 3 @objc inference” logging enabled, and then disable inference by changing the "Swift 3 @objc Inference" build setting to "Default" for the "DatezTests-ios" target.

> The use of Swift 3 @objc inference in Swift 4 mode is deprecated. Please address deprecated @objc inference warnings, test your code with “Use of deprecated Swift 3 @objc inference” logging enabled, and then disable inference by changing the "Swift 3 @objc Inference" build setting to "Default" for the "Datez-ios" target.

When I tired to solve them I got error, so I will try again to solve them. I don't know how long it will take from me.